### PR TITLE
[feat] 네이버 지도 추가(#2)

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -6,7 +6,6 @@ const Container: FC = ({ children }) => <Wrapper>{children}</Wrapper>;
 export default Container;
 
 const Wrapper = styled.div`
-  width: 90%;
-  min-width: 325px;
-  margin: 0 auto;
+  width: 100%;
+  height: 100%;
 `;

--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -1,0 +1,35 @@
+import Head from "next/head";
+import React, { FC, useEffect } from "react";
+import styled from "styled-components";
+
+interface NaverMapProps {
+  temp?: string;
+}
+
+const NaverMap: FC<NaverMapProps> = () => {
+  useEffect(() => {
+    const map = new naver.maps.Map("map", {
+      center: new naver.maps.LatLng(37.3595704, 127.105399),
+      zoom: 10,
+    });
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <script
+          type="text/javascript"
+          src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=fqmdjzxln0"
+        ></script>
+      </Head>
+      <MapWrapper id="map" />
+    </>
+  );
+};
+
+export default NaverMap;
+
+const MapWrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,11 @@
 import React, { FC } from "react";
 
-const IndexPage: FC = () => <div>Index</div>;
+import NaverMap from "components/NaverMap";
+
+const IndexPage: FC = () => (
+  <div>
+    <NaverMap />
+  </div>
+);
 
 export default IndexPage;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,66 @@
+interface NaverMap {
+  Animation: any;
+  BicycleLayer: function;
+  CadastralLayer: function;
+  CanvasMapType: function;
+  CanvasTile: function;
+  Circle: function;
+  CustomControl: function;
+  Data: function;
+  DataConverter: any;
+  EPSG3857: any;
+  Ellipse: function;
+  EmptyProjection: any;
+  Event: any;
+  Feature: function;
+  Geometry: function;
+  GroundOverlay: function;
+  ImageMapType: function;
+  ImageTile: function;
+  InfoWindow: function;
+  KVO: function;
+  KVOArray: function;
+  LabelLayer: function;
+  LatLng: function;
+  LatLngBounds: function;
+  Layer: function;
+  LogoControl: function;
+  Map: function;
+  MapDataControl: function;
+  MapTypeControl: function;
+  MapTypeControlStyle: any;
+  MapTypeId: any;
+  MapTypeRegistry: function;
+  Marker: function;
+  NaverMapTypeOption: function;
+  NaverStyleMapTypeOption: function;
+  OverlayView: function;
+  PaneTypeRegistry: function;
+  Point: function;
+  PointBounds: function;
+  PointingIcon: any;
+  Polygon: function;
+  Polyline: function;
+  Position: any;
+  Projection: function;
+  Rectangle: function;
+  ScaleControl: function;
+  Size: function;
+  StreetLayer: function;
+  SymbolPath: any;
+  SymbolStyle: any;
+  Tile: function;
+  TileIndexPane: function;
+  TrafficLayer: function;
+  UTMK: any;
+  UTMK_NAVER: any;
+  Util: any;
+  ZoomControl: function;
+  ZoomControlStyle: any;
+  jsContentLoaded: boolean;
+  onJSContentLoaded: any;
+}
+
+declare namespace naver {
+  const maps: NaverMap;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,7 @@
     "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": ["./types"],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */


### PR DESCRIPTION
## 스크린샷
![스크린샷 2021-02-27 오전 2 13 40](https://user-images.githubusercontent.com/312621/109332470-7dc40c00-78a1-11eb-84f6-52c715995219.png)


## 작업 내용
#2 를 적용하여 화면 전체에 네이버 지도를 뿌려줍니다.
아직 지도를 화면에 넣는 부분만 작업하여 나머지 로직은 해커톤 당일 추가 예정입니다.