### PR TITLE
[feat] 탭 구현

### DIFF
--- a/public/tab_list.svg
+++ b/public/tab_list.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.3333 17H3.66667V8.27273H1L9 1L17 8.27273H14.3333V12.6364" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/tab_my.svg
+++ b/public/tab_my.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 7H11" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 11H9" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 7.5V5C3 3.34315 4.34315 2 6 2H14C15.6569 2 17 3.34315 17 5V15C17 16.6569 15.6569 18 14 18H6C4.34315 18 3 16.6569 3 15V14" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/tab_pick.svg
+++ b/public/tab_pick.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 10.8L4 12.9L1 15V1H13V15L10 12.4545" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -22,6 +22,11 @@ const NaverMap: FC<NaverMapProps> = () => {
       new naver.maps.Map("map", {
         center: new naver.maps.LatLng(37.3595704, 127.105399),
         zoom: 15,
+        zoomControl: true,
+        zoomControlOptions: {
+          style: naver.maps.ZoomControlStyle.SMALL,
+          position: naver.maps.Position.TOP_RIGHT,
+        },
       }),
     );
   }, []);

--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -139,6 +139,7 @@ export default SearchInput;
 
 const Wrapper = styled.div<{ isDropdownShown?: boolean }>`
   position: relative;
+  z-index: 1;
   border: 1px solid #cbcbcb;
 
   ${(props) =>

--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -94,7 +94,11 @@ const SearchInput: FC = () => {
   };
 
   return (
-    <Wrapper onBlur={handleBlur} tabIndex={-1}>
+    <Wrapper
+      onBlur={handleBlur}
+      tabIndex={-1}
+      isDropdownShown={isDropdownShown}
+    >
       <InputWrapper isDropdownShown={isDropdownShown}>
         <StyledInput
           value={keyword}
@@ -111,8 +115,8 @@ const SearchInput: FC = () => {
           onClick={handleSearch}
         />
       </InputWrapper>
-      {isDropdownShown &&
-        (isSearched ? (
+      <Dropdown isDropdownShown={isDropdownShown}>
+        {isSearched ? (
           <SearchResults
             results={results}
             onClick={handleItemClick}
@@ -125,16 +129,28 @@ const SearchInput: FC = () => {
             onKeywordClick={handleItemClick}
             onRemoveItem={handleRecentKeywordRemove}
           />
-        ))}
+        )}
+      </Dropdown>
     </Wrapper>
   );
 };
 
 export default SearchInput;
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ isDropdownShown?: boolean }>`
+  position: relative;
   border: 1px solid #cbcbcb;
+
+  ${(props) =>
+    (props.isDropdownShown ?
+      `
+      border-top-left-radius: 25px;
+      border-top-right-radius: 25px;
+      border-bottom: none;
+  ` :
+      `
   border-radius: 25px;
+  `)}
   outline: none;
 `;
 
@@ -154,4 +170,23 @@ const StyledInput = styled.input`
   font-size: 16px;
   border: none;
   outline: none;
+`;
+
+const Dropdown = styled.div<{ isDropdownShown?: boolean }>`
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: calc(100% + 2px);
+  background: white;
+
+  ${(props) =>
+    (props.isDropdownShown ?
+      `
+    display: block;
+    border: 1px solid #cbcbcb;
+    border-top: none;
+    border-bottom-left-radius: 25px;
+      border-bottom-right-radius: 25px;
+  ` :
+      "display: none;")}
 `;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,25 +1,47 @@
 import Image from "next/image";
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import styled from "styled-components";
 
 import SearchInput from "./SearchInput";
+import Tab from "./Tab";
 
-const Sidebar: FC = () => (
-  <SidebarWrapper>
-    <MainSection>
-      <Logo>
-        <Image src="/logo.png" alt="logo" width="68px" height="68px" />
-        <Image
-          src="/logo_text.png"
-          alt="logo_text"
-          width="auto"
-          height="31px"
-        />
-      </Logo>
-      <SearchInput />
-    </MainSection>
-  </SidebarWrapper>
-);
+const Sidebar: FC = () => {
+  const [currentTab, setCurrentTab] = useState(0);
+
+  return (
+    <SidebarWrapper>
+      <MainSection>
+        <Logo>
+          <Image src="/logo.png" alt="logo" width="68px" height="68px" />
+          <Image
+            src="/logo_text.png"
+            alt="logo_text"
+            width="auto"
+            height="31px"
+          />
+        </Logo>
+        <SearchInput />
+        <Tab
+          currentTab={currentTab}
+          onTabChange={(index) => setCurrentTab(index)}
+        >
+          <div>
+            <Image src="/tab_list.svg" alt="list" width={16} height={16} />
+            입담리스트
+          </div>
+          <div>
+            <Image src="/tab_pick.svg" alt="list" width={16} height={16} />
+            관심리뷰
+          </div>
+          <div>
+            <Image src="/tab_my.svg" alt="list" width={16} height={16} />
+            마이리뷰
+          </div>
+        </Tab>
+      </MainSection>
+    </SidebarWrapper>
+  );
+};
 
 export default Sidebar;
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import React, { FC, useState } from "react";
+import React, { FC, useMemo, useState } from "react";
 import styled from "styled-components";
 
 import SearchInput from "./SearchInput";
@@ -7,6 +7,18 @@ import Tab from "./Tab";
 
 const Sidebar: FC = () => {
   const [currentTab, setCurrentTab] = useState(0);
+
+  const renderTabContent = useMemo(() => {
+    switch (currentTab) {
+      case 1:
+        return <>관심리뷰</>;
+      case 2:
+        return <>마이리뷰</>;
+      case 0:
+      default:
+        return <>입담리스트</>;
+    }
+  }, [currentTab]);
 
   return (
     <SidebarWrapper>
@@ -38,6 +50,7 @@ const Sidebar: FC = () => {
             마이리뷰
           </div>
         </Tab>
+        <TabContent>{renderTabContent}</TabContent>
       </MainSection>
     </SidebarWrapper>
   );
@@ -65,6 +78,13 @@ const SidebarWrapper = styled.div`
 `;
 
 const MainSection = styled.div`
+  display: flex;
+  flex-direction: column;
   width: 590px;
   height: 100%;
+`;
+
+const TabContent = styled.div`
+  flex: 1;
+  margin-top: 20px;
 `;

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,0 +1,70 @@
+import React, { FC, PropsWithChildren } from "react";
+import styled from "styled-components";
+
+interface TabProps {
+  currentTab: number;
+  onTabChange: (index: number) => void;
+}
+
+const Tab: FC<TabProps> = ({
+  children,
+  currentTab,
+  onTabChange,
+}: PropsWithChildren<TabProps>) => (
+  <TabWrapper>
+    {React.Children.map(children, (c, index) => (
+      <TabItem
+        key={index}
+        isActive={currentTab === index}
+        onClick={() => onTabChange(index)}
+      >
+        {c}
+      </TabItem>
+    ))}
+  </TabWrapper>
+);
+
+export default Tab;
+
+const TabWrapper = styled.div`
+  display: flex;
+  margin-top: 34px;
+  border-bottom: 1px solid #9c9c9c;
+`;
+
+const TabItem = styled.div<{ isActive?: boolean }>`
+  position: relative;
+  width: 115px;
+  padding-bottom: 10px;
+  font-size: 18px;
+  text-align: center;
+
+  div {
+    margin-right: 6px;
+  }
+
+  ${(props) =>
+    (props.isActive ?
+      `
+    color: black;
+    font-weight: 700;
+
+    &:after {
+      position: absolute;
+      bottom: -1px;
+      left: 0;
+      width: 100%;
+      height: 2px;
+      background: black;
+      content: "";
+    }
+    ` :
+      `
+    color: #696969;
+    font-weight: 500;
+
+    img {
+      display: none !important;
+    }
+    `)}
+`;


### PR DESCRIPTION
## 구현 이미지

<img width="628" alt="스크린샷 2021-02-28 오전 5 07 45" src="https://user-images.githubusercontent.com/312621/109398908-e9ca7100-7982-11eb-81c0-56bc3deb9da1.png">


# 구현 내용

- 탭을 구현합니다.
- 드롭다운이 absolute가 아니라서 드롭다운이 열리면 탭이 아래로 밀리던 현상 해결
- SearchInput에 zIndex를 줘서 드롭다운이 열려도 상위를 차지하도록 수정