### PR TITLE
[fix] 사이드바 브랜치에서 지도 줌 컨트롤 제거

### DIFF
--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -22,11 +22,6 @@ const NaverMap: FC<NaverMapProps> = () => {
       new naver.maps.Map("map", {
         center: new naver.maps.LatLng(37.3595704, 127.105399),
         zoom: 15,
-        zoomControl: true,
-        zoomControlOptions: {
-          style: naver.maps.ZoomControlStyle.SMALL,
-          position: naver.maps.Position.TOP_RIGHT,
-        },
       }),
     );
   }, []);


### PR DESCRIPTION
원본 브랜치가 이미 머지되어 PR을 다시 올립니다.