### PR TITLE
[feat] 디자인에 따른 마커 추가(#20)

### DIFF
--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -38,9 +38,18 @@ const NaverMap: FC<NaverMapProps> = () => {
           position: new naver.maps.LatLng(info.position.lat, info.position.lng),
           map,
           icon: {
-            url: "/marker.png",
-            size: new naver.maps.Size(32, 44),
-            scaledSize: new naver.maps.Size(32, 44),
+            content: [
+              "<div class='marker-wrapper'>",
+              "<div class='marker-info'>",
+              `${info.name}`,
+              "<span class='marker-review'>",
+              `리뷰 ${(info.reviews?.length ?? 0)}개`,
+              "</span>",
+              "</div>",
+              "<img class='marker-img' src='/marker.png' />",
+              "</div>",
+            ].join(""),
+            anchor: new naver.maps.Point(22, 60),
           },
         }),
     );
@@ -72,4 +81,50 @@ export default NaverMap;
 const MapWrapper = styled.div`
   flex: 1;
   height: 100vh;
+
+  .marker-wrapper {
+    position: relative;
+  }
+
+  .marker-info {
+    position: absolute;
+    bottom: calc(100% + 25px);
+    left: 50%;
+    width: max-content;
+    padding: 20px 18px 22px 18px;
+    font-weight: 700;
+    font-size: 16px;
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 10px 16px rgba(0, 0, 0, 0.1);
+    transform: translateX(-50%);
+
+    /* 말풍선의 꼭짓점 */
+    &::after {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      border-top: 13px solid white;
+      border-right: 8px solid transparent;
+      border-bottom: 0 solid transparent;
+      border-left: 8px solid transparent;
+      transform: translateX(-50%);
+      content: "";
+    }
+  }
+
+  .marker-review {
+    margin-left: 10px;
+    padding: 3px 7px 5px 7px;
+    color: #8b8b8b;
+    font-weight: 500;
+    font-size: 15px;
+    background-color: rgba(196, 196, 196, 0.15);
+    border-radius: 8px;
+  }
+
+  .marker-img {
+    width: 44px;
+    height: 60px;
+  }
 `;

--- a/src/types/Marker.ts
+++ b/src/types/Marker.ts
@@ -2,6 +2,9 @@ import LatLng from "./LatLng";
 
 interface Marker {
   position: LatLng;
+  name: string;
+  // 마커 클릭시 바로 확인 가능하도록 마커에 review의 id들을 수집할 예정
+  reviews: number[];
 }
 
 export default Marker;

--- a/src/utils/states/naverMapState.ts
+++ b/src/utils/states/naverMapState.ts
@@ -11,7 +11,15 @@ interface NaverMapStateProps {
 const naverMapState = atom<NaverMapStateProps>({
   key: "naverMapState",
   default: {
-    markers: [],
+    // 임시 좌표(영진's house)
+    markers: [{
+      position: {
+        lat: 37.47699619488476,
+        lng: 126.95409135525202,
+      },
+      name: "서울대학교",
+      reviews: [1, 2, 3],
+    }],
     center: {
       lat: 37.47699619488476,
       lng: 126.95409135525202,


### PR DESCRIPTION
<img width="1437" alt="스크린샷 2021-03-28 오후 4 46 28" src="https://user-images.githubusercontent.com/312621/112745771-c7f5f580-8fe5-11eb-8d7f-b058d20b7ff9.png">

# 구현 내용
- 마커를 디자인에 맞게 구현합니다
- 마커에 정보를 담기 위해 마커 타입에 이름과 리뷰 id를 저장해놓은 배열을 추가합니다